### PR TITLE
refactor(pdf-viewer): remove unused zoom effect and improve viewer component structure

### DIFF
--- a/src/app/components/PDFViewer.tsx
+++ b/src/app/components/PDFViewer.tsx
@@ -42,21 +42,16 @@ export default function PDFViewer({ fileUrl }: PDFViewerProps) {
         })
     ).current;
 
-    // Set zoom to page width after the bookmark tab is open
-    useEffect(() => {
-        // Wait a tick to ensure the sidebar is open
-        const timeout = setTimeout(() => {
-            customZoomPluginInstance.zoomTo(SpecialZoomLevel.PageWidth);
-        }, 300);
-        return () => clearTimeout(timeout);
-    }, [customZoomPluginInstance]);
-
     return (
         <div className="flex flex-col w-full min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
             <div className="flex-1 flex justify-center items-center p-6">
                 <div className="bg-white shadow-2xl rounded-lg overflow-hidden w-full max-w-7xl" style={{ height: '95vh' }}>
                     <Worker workerUrl="https://unpkg.com/pdfjs-dist@3.4.120/build/pdf.worker.min.js">
-                        <Viewer fileUrl={fileUrl} plugins={[defaultLayoutPluginInstance, customZoomPluginInstance]} />
+                        <Viewer 
+                            fileUrl={fileUrl} 
+                            defaultScale={1.5}
+                            plugins={[defaultLayoutPluginInstance, customZoomPluginInstance]} 
+                        />
                     </Worker>
                 </div>
             </div>


### PR DESCRIPTION
PDF Zoom Behavior:

* Removed the `useEffect` hook that previously set the zoom to page width after the bookmark tab was opened, simplifying the component's logic.
* Set a new default zoom level by adding the `defaultScale={1.5}` prop to the `Viewer` component, ensuring PDFs open at a consistent scale.