### PR TITLE
fix(blog): conditionally adjust layout and Table of Contents for specific blog post

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -127,7 +127,7 @@ export default async function BlogPost({ params }: { params: { slug: string } })
 
         {/* Body */}
         <div className="flex justify-between items-start relative gap-12">
-          <div className="w-full lg:w-[calc(100%-20rem)]">
+          <div className={`w-full ${params.slug !== 'cosdata-vs-qdrant-a-comprehensive-vector-database-performance-benchmark' ? 'lg:w-[calc(100%-20rem)]' : ''}`}>
             <div
               className={`prose prose-lg max-w-none text-[#374151] ${afacad.className} text-lg sm:text-xl
                 prose-headings:text-[#0055c8] prose-headings:font-semibold
@@ -166,7 +166,7 @@ export default async function BlogPost({ params }: { params: { slug: string } })
             </footer>
           </div>
 
-          <TableOfContents />
+          {params.slug !== 'cosdata-vs-qdrant-a-comprehensive-vector-database-performance-benchmark' && <TableOfContents />}
         </div>
       </article>
     </div>


### PR DESCRIPTION
Layout and conditional rendering updates:

* The main content container now uses full width and omits the right sidebar width constraint for the specified blog post slug (`cosdata-vs-qdrant-a-comprehensive-vector-database-performance-benchmark`). ([src/app/blog/[slug]/page.tsxL130-R130](diffhunk://#diff-7982871d233df68cc6cee151ccebf838f98bc4923f8a050a9cf2217e6b3a27f7L130-R130))
* The `TableOfContents` component is conditionally rendered for all posts except the one with the specified slug, effectively hiding it for that post. ([src/app/blog/[slug]/page.tsxL169-R169](diffhunk://#diff-7982871d233df68cc6cee151ccebf838f98bc4923f8a050a9cf2217e6b3a27f7L169-R169))